### PR TITLE
Fix UAF in process_recv

### DIFF
--- a/usbfluxd/client.c
+++ b/usbfluxd/client.c
@@ -977,8 +977,9 @@ static void process_recv(struct mux_client *client)
 		if(client->ib_size < hdr->length)
 			return;
 	}
-	client_command(client, hdr);
-	client->ib_size = 0;
+	if (client_command(client, hdr) == 0) {
+		client->ib_size = 0;
+	}
 }
 
 void client_process(int fd, short events)


### PR DESCRIPTION
In `process_recv`, there is no handling for an error on
`client_command`, which may interally free the `client` (by calling
`client_close`). This results in a UAF:

	client_command(client, hdr);
	client->ib_size = 0;

Log:

	[11:26:04.715][3] NOTE: remote 10.11.1.1:5000 is no longer available.
	[11:37:12.068][4] New client on fd 5 (pid 9809)
	[11:37:12.069][1] Client 5 command received in the wrong state
	[11:37:12.069][4] Disconnecting client 0x6080000007a0 fd 5

ASan:

	==5624==ERROR: AddressSanitizer: heap-use-after-free on address 0x6080000007c0 at pc 0x5643f34e1b79 bp 0x7ffe58b9f170 sp 0x7ffe58b9f160
	WRITE of size 4 at 0x6080000007c0 thread T0
	    #0 0x5643f34e1b78 in process_recv /usbfluxd/usbfluxd/client.c:981
	    #1 0x5643f34e26a0 in client_process /usbfluxd/usbfluxd/client.c:1043
	    #2 0x5643f34f03cb in main_loop /usbfluxd/usbfluxd/main.c:156
	    #3 0x5643f34f186c in main /usbfluxd/usbfluxd/main.c:477
	    #4 0x7f3152cffb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
	    #5 0x5643f34d995d in _start (/usr/local/sbin/usbfluxd+0xa95d)

	0x6080000007c0 is located 32 bytes inside of 96-byte region [0x6080000007a0,0x608000000800)
	freed by thread T0 here:
	    #0 0x7f31530f6f19 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:127
	    #1 0x5643f34dac29 in client_close /usbfluxd/usbfluxd/client.c:254
	    #2 0x5643f34ddeac in client_command /usbfluxd/usbfluxd/client.c:642
	    #3 0x5643f34e1b45 in process_recv /usbfluxd/usbfluxd/client.c:980
	    #4 0x5643f34e26a0 in client_process /usbfluxd/usbfluxd/client.c:1043
	    #5 0x5643f34f03cb in main_loop /usbfluxd/usbfluxd/main.c:156
	    #6 0x5643f34f186c in main /usbfluxd/usbfluxd/main.c:477
	    #7 0x7f3152cffb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

	previously allocated by thread T0 here:
	    #0 0x7f31530f7279 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
	    #1 0x5643f34da34c in client_accept /usbfluxd/usbfluxd/client.c:199
	    #2 0x5643f34f023e in main_loop /usbfluxd/usbfluxd/main.c:149
	    #3 0x5643f34f186c in main /usbfluxd/usbfluxd/main.c:477
	    #4 0x7f3152cffb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

	SUMMARY: AddressSanitizer: heap-use-after-free /usbfluxd/usbfluxd/client.c:981 in process_recv
	Shadow bytes around the buggy address:
	  0x0c107fff80a0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
	  0x0c107fff80b0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
	  0x0c107fff80c0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
	  0x0c107fff80d0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
	  0x0c107fff80e0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
	=>0x0c107fff80f0: fa fa fa fa fd fd fd fd[fd]fd fd fd fd fd fd fd
	  0x0c107fff8100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
	  0x0c107fff8110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
	  0x0c107fff8120: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
	  0x0c107fff8130: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
	  0x0c107fff8140: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
	Shadow byte legend (one shadow byte represents 8 application bytes):
	  Addressable:           00
	  Partially addressable: 01 02 03 04 05 06 07
	  Heap left redzone:       fa
	  Freed heap region:       fd
	  Stack left redzone:      f1
	  Stack mid redzone:       f2
	  Stack right redzone:     f3
	  Stack after return:      f5
	  Stack use after scope:   f8
	  Global redzone:          f9
	  Global init order:       f6
	  Poisoned by user:        f7
	  Container overflow:      fc
	  Array cookie:            ac
	  Intra object redzone:    bb
	  ASan internal:           fe
	  Left alloca redzone:     ca
	  Right alloca redzone:    cb
	  Shadow gap:              cc
	==5624==ABORTING