### PR TITLE
Fix gethostbyname(3) data race

### DIFF
--- a/usbfluxd/usbmux_remote.c
+++ b/usbfluxd/usbmux_remote.c
@@ -54,6 +54,7 @@
 
 static struct collection remote_list;
 pthread_mutex_t remote_list_mutex;
+extern pthread_mutex_t gethostbyname_mutex;
 static plist_t remote_device_list = NULL;
 static uint8_t remote_id_map[32];
 static int opt_no_mdns = 0;
@@ -800,6 +801,7 @@ void usbmux_remote_init(int no_mdns)
 	usbfluxd_log(LL_DEBUG, "%s", __func__);
 
 	collection_init(&remote_list);
+	pthread_mutex_init(&gethostbyname_mutex, NULL);
 	pthread_mutex_init(&remote_list_mutex, NULL);
 	remote_device_list = plist_new_dict();
 	memset(&remote_id_map, '\0', sizeof(remote_id_map));
@@ -851,6 +853,7 @@ void usbmux_remote_shutdown(void)
 	} ENDFOREACH
 	pthread_mutex_unlock(&remote_list_mutex);
 	pthread_mutex_destroy(&remote_list_mutex);
+	pthread_mutex_destroy(&gethostbyname_mutex);
 	collection_free(&remote_list);
 	plist_free(remote_device_list);
 	remote_device_list = NULL;


### PR DESCRIPTION
Under certain conditions, such as a network failure,
`socket_connect_timeout` will race to call *gethostbyname*(3) and end up
dereferencing NULL:

	if ((hp = gethostbyname(addr)) == NULL) {
		usbfluxd_log(LL_ERROR, "%s: unknown host '%s'", __func__, addr);
		return -1;
	}

	// Passes, data is fine
	if (!hp->h_addr) {
		usbfluxd_log(LL_ERROR, "%s: gethostbyname returned NULL address!", __func__);
		return -1;
	}

	// ...
	// Another thread calls gethostbyname, hp is now pointing to another instance (data race)
	// ...

	// BOOM
	saddr.sin_addr.s_addr = *(uint32_t *) hp->h_addr;

The man page makes this apparent:

       The  functions  gethostbyname()  and gethostbyaddr() may return pointers to static data, which may be overwritten by
       later calls.  Copying the struct hostent does not suffice, since it contains pointers; a deep copy is required.

ASan:

	==28115==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x561c82fb46e6 bp 0x7f8520a20ca0 sp 0x7f8520a20ae0 T357)
	==28115==The signal is caused by a READ memory access.
	==28115==Hint: address points to the zero page.
	    #0 0x561c82fb46e6 in socket_connect_timeout /usbfluxd/usbfluxd/socket.c:153
	    #1 0x561c82fba741 in check_remote_func /usbfluxd/usbfluxd/usbmux_remote.c:949
	    #2 0x7f85da806258 in start_thread (/usr/lib/libpthread.so.0+0x9258)
	    #3 0x7f85da5c75e2 in __GI___clone (/usr/lib/libc.so.6+0xfe5e2)

	AddressSanitizer can not provide additional info.
	SUMMARY: AddressSanitizer: SEGV /usbfluxd/usbfluxd/socket.c:153 in socket_connect_timeout
	Thread T357 created by T0 here:
	    #0 0x7f85da889fa7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:216
	    #1 0x561c82fbaa4b in usbmux_remote_get_fds /usbfluxd/usbfluxd/usbmux_remote.c:967
	    #2 0x561c82fc0ef2 in main_loop /usbfluxd/usbfluxd/main.c:129
	    #3 0x561c82fc2870 in main /usbfluxd/usbfluxd/main.c:477
	    #4 0x7f85da4f0b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)