### PR TITLE
Incorrect dependency in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Installation From Source
 
 To compile run:
 ```zsh
-# brew install make autoheader automake autoconf libtool pkg-config gcc libimobiledevice
+# brew install make automake autoconf libtool pkg-config gcc libimobiledevice usbmuxd
 
 git clone https://github.com/corellium/usbfluxd.git
 cd usbfluxd


### PR DESCRIPTION
`autoheader` doesn't exit at homebrew

Also, would you like these instructions added?

https://github.com/sickcodes/Docker-OSX#usbfluxd-iphone-usb---network-style-passthrough-osx-kvm-docker-osx