### PR TITLE
(doc) update usbmuxd to libusbmuxd

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Installation From Source
 
 To compile run:
 ```zsh
-# brew install make automake autoconf libtool pkg-config gcc libimobiledevice usbmuxd
+# brew install make automake autoconf libtool pkg-config gcc libimobiledevice libusbmuxd
 
 git clone https://github.com/corellium/usbfluxd.git
 cd usbfluxd


### PR DESCRIPTION
While both appear to still be the same version, a deprecation
warning is shown when using homebrew to install usbmuxd. eg:

```text
❯ brew info usbmuxd
Warning: Use libusbmuxd instead of deprecated usbmuxd
libusbmuxd: stable 2.0.2 (bottled), HEAD
```

```text
❯ brew info libusbmuxd
libusbmuxd: stable 2.0.2 (bottled), HEAD
```