### PR TITLE
Update usbfluxd

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ make
 sudo make install
 ```
 
-Also available from the Arch User Repository for Linux hosts: [https://aur.archlinux.org/packages/usbfluxd/](https://aur.archlinux.org/packages/usbfluxd/)
-
+Also available from the Arch User Repository for Linux hosts:
+- [https://aur.archlinux.org/packages/usbfluxd/](https://aur.archlinux.org/packages/usbfluxd/)
+- [https://aur.archlinux.org/packages/usbfluxd-git/](https://aur.archlinux.org/packages/usbfluxd-git/)
 
 Linux Usage
 ===========

--- a/configure.ac
+++ b/configure.ac
@@ -72,17 +72,13 @@ AC_ARG_WITH([static-libplist],
             [AS_HELP_STRING(["--with-static-libplist[=/path/to/static/libplist"]],
             [link against a static libplist])],
             [with_static_libplist=$withval],
-            [with_static_libplist=yes])
-if test "x$with_static_libplist" != "xno"; then
-  if test "x$with_static_libplist" = "xyes"; then
-    STATIC_LIBPLIST="`pkg-config --libs-only-L libplist-2.0 |sed 's/^..//; s/[ ]*$/\/libplist-2.0.a/'`"
-  else
-    STATIC_LIBPLIST="$with_static_libplist"
-  fi
-  if ! test -f "$STATIC_LIBPLIST"; then
-    AC_MSG_ERROR([The file ${STATIC_LIBPLIST} passed to --with-static-libplist does not exist])
-  fi
-  AC_SUBST(libplist_LIBS, [$STATIC_LIBPLIST])
+            [with_static_libplist=no])
+if test "x$with_static_libplist" = xno; then
+  PKG_CHECK_MODULES(libplist, libplist-2.0 >= 2.2.0)
+else
+  # Use the static libplist from the specified path
+  AC_SUBST(libplist_CFLAGS, "-I${with_static_libplist}/include")
+  AC_SUBST(libplist_LIBS, "${with_static_libplist}/lib/libplist.a")
 fi
 
 AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-g -Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith  -Wwrite-strings -Wswitch-default -Wno-unused-parameter")

--- a/usbfluxd/Makefile.am
+++ b/usbfluxd/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)
 AM_CFLAGS = $(GLOBAL_CFLAGS) $(libplist_CFLAGS) $(avahi_client_CFLAGS)
 AM_LDFLAGS = $(libplist_LIBS) $(libpthread_LIBS) $(avahi_client_LIBS) $(AC_LDADD)
 
-sbin_PROGRAMS = usbfluxd
+bin_PROGRAMS = usbfluxd
 
 usbfluxd_CFLAGS = $(AM_CFLAGS)
 usbfluxd_LDFLAGS = $(AM_LDFLAGS) -no-undefined


### PR DESCRIPTION
- compile using the system `libplist` library. 
- modify the `sbin` from `sbin` to the standard `bin`, and users use `sudo/doas` to raise the right to use. 
- add links to AUR usbfluxd-git packages